### PR TITLE
fix(Drag): throttle dragover processing to improve drag performance

### DIFF
--- a/packages/he-tree-vue/src/components/DraggableTree.ts
+++ b/packages/he-tree-vue/src/components/DraggableTree.ts
@@ -106,8 +106,10 @@ const cpt = defineComponent({
   data() {
     return {
       treeDraggableInstance: null,
+      dragOverRAF: null,
     } as {
       treeDraggableInstance: ExtendedDND | null;
+      dragOverRAF: number | null;
     };
   },
   computed: {},
@@ -115,6 +117,16 @@ const cpt = defineComponent({
     getNodeByElement(el: HTMLElement): Stat<any> | null {
       const i = el.getAttribute("vt-index");
       return i == null ? null : this.visibleStats[i];
+    },
+    throttleDragOver(processingFn: () => void) {
+      if (this.dragOverRAF !== null) {
+        return;
+      }
+
+      this.dragOverRAF = requestAnimationFrame(() => {
+        this.dragOverRAF = null;
+        processingFn();
+      });
     },
     isDraggable(node: Stat<any>): boolean {
       if (this.disableDrag) {
@@ -429,7 +441,9 @@ const cpt = defineComponent({
                 y: startMovePoint.y + (mouse.y - startMouse.y),
               }
             : { ...mouse };
-          const { btt, rtl } = targetTree;
+
+          this.throttleDragOver(() => {
+            const { btt, rtl } = targetTree;
           // if undroppable, return
           if (targetTree!.disableDrop) {
             ctx.dropEffect = "none";
@@ -708,6 +722,7 @@ const cpt = defineComponent({
             // move placeholder
             movePlaceholder(dp.parent, dp.index);
           });
+          });
         },
         () => {
           // do nothing
@@ -842,6 +857,10 @@ const cpt = defineComponent({
   },
   unmounted() {
     this.treeDraggableInstance?.destroy();
+    if (this.dragOverRAF !== null) {
+      cancelAnimationFrame(this.dragOverRAF);
+      this.dragOverRAF = null;
+    }
   },
 });
 export default cpt;


### PR DESCRIPTION
The current dragover event fires continuously while dragging, causing expensive operations like tree traversal, drop zone calculations, etc. For larger data sets this causes a weird delay while dragging. While you can work around this using the [virtualization](https://hetree.phphe.com/v2/api#virtualization) setting, this might not always be a suitable solution where you cannot limit the height of the parent.

![2025-09-14 13 31 57](https://github.com/user-attachments/assets/99761f16-04fe-47d3-80be-38705c727514)

The introduced `throttleDragOver()` method uses requestAnimationFrame() to limit processing to once per frame 

![2025-09-14 13 30 53](https://github.com/user-attachments/assets/3aad7062-92ae-45be-807e-6c38078bae4c)
