### PR TITLE
fix(tree-utils): correct half-checked state calculation in updateCheck

### DIFF
--- a/packages/tree-utils/src/index.ts
+++ b/packages/tree-utils/src/index.ts
@@ -156,7 +156,9 @@ export function makeTreeProcessor<T>(data: T[], opt: Options = {}) {
         this.stats!,
         (stat) => {
           if (stat.children && stat.children.length > 0) {
-            const checked = stat.children.every((v) => v.checked);
+            const allChecked = stat.children.every((v) => v.checked === true);
+            const allUnchecked = stat.children.every((v) => v.checked === false);
+            const checked = allChecked ? true : allUnchecked ? false : 0;
             if (stat.checked !== checked) {
               this._ignoreCheckedOnce(stat);
               stat.checked = checked;


### PR DESCRIPTION
## Summary

Fixed parent node checked state calculation to properly return the half-checked state (`0`) when children have mixed checked/unchecked states.

## Problem

The previous implementation only returned `true`/`false`, missing the half-checked state (`0`) defined in the documentation when some children were checked.

## Solution

Updated logic to explicitly check all three states:
- `true`: all children checked
- `false`: all children unchecked
- `0`: mixed state